### PR TITLE
Don't redirect engine stderr

### DIFF
--- a/src/back/TlcvExtensionsHost/Services/Engine.cs
+++ b/src/back/TlcvExtensionsHost/Services/Engine.cs
@@ -37,7 +37,7 @@ public partial class Engine
             FileName = config.Path,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
-            RedirectStandardError = true,
+            RedirectStandardError = false,
             UseShellExecute = false,
             CreateNoWindow = true
         };


### PR DESCRIPTION
This addresses a bug where the stderr buffer can fill up, potentially resulting in the engine deadlocking.

This fixes GediminasMasaitis/TlcvExtensions#4