### PR TITLE
Trigger webapp shutdown on application exit.

### DIFF
--- a/src/back/TlcvExtensionsHost/Program.cs
+++ b/src/back/TlcvExtensionsHost/Program.cs
@@ -31,8 +31,11 @@ app.MapPost("/fen",
         return new FenResponse(engineManager.Engines.ConvertAll(x => x.Config));
     });
 
+bool didShutDown = false;
+
 app.Lifetime.ApplicationStarted.Register(() => app.Services.GetRequiredService<EngineManager>().Run());
-app.Lifetime.ApplicationStopping.Register(() => StopEngineProcesses(app));
+app.Lifetime.ApplicationStopping.Register(() => { didShutDown = true; StopEngineProcesses(app); });
+AppDomain.CurrentDomain.ProcessExit += (e, a) => { if (!didShutDown) app.Lifetime.StopApplication(); };
 
 await app.RunAsync();
 


### PR DESCRIPTION
This fixes GediminasMasaitis/TlcvExtensions#3.

Not the most elegant solution... but I think it works.

Explanation:

 * When running the backend app in its own window (as explained in the issue), hitting the window's 'x' button triggers `AppDomain.CurrentDomain.ProcessExit`, but not `app.Lifetime.ApplicationStopping`. So in order to trigger a graceful shutdown, we simply command the app to end its lifetime when `ProcessExit` is triggered.
 * When running the backend app from a terminal, sending Ctrl+C triggers both `AppDomain.CurrentDomain.ProcessExit` and `app.Lifetime.ApplicationStopping`, and disposal of the `app` object. In order to avoid referencing a disposed object (namely `app`) from the `ProcessExit` handler we need to set a flag to indicate that we've already done the shutdown.

Testing done:

 * Ran the following three scenarios:
     * Ran TlcvExtensionsHost from Visual studio (resulting in it running in its own window)
     * Ran TlcvExtensionsHost from Windows explorer (resulting in it running in its own window)
     * Ran TlcvExtensionsHost from a terminal.
 * In each scenario:
     * Checked that `quit` was sent to the engine (by attaching a debugger to the engine and setting a breakpoint on the `quit` handler)
     * Checked that the TlcvExtensionsHost app shut down gracefully (no exceptions, exit code 0, prints "Graceful shutdown completed")
     * Checked that there aren't any zombie engine processes after shutdown.