### PR TITLE
feat: replace deprecated DOMSubtreeModified with MutationObserver API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Alternatively, you can always build the backend yourself (.NET 8.0 required) and
 
 ### Front end
 
-1. Install a usercript runner. Only tested on Firefox and Violentmonkey plugin.
+1. Install a usercript runner. Only tested on both Firefox and Chrome with the userscript managers Violentmonkey and Tampermonkey.
 2. Copy [`ccrlExtensions.js`](src/front/ccrlExtensions.js) into a new userscript and save changes.
 
 ![Screenshot of Violentmonkey setup](https://github.com/GediminasMasaitis/CcrlExtensions/assets/11148519/13439011-eb74-4004-8ba9-1b5399e248b5)

--- a/src/front/ccrlExtensions.js
+++ b/src/front/ccrlExtensions.js
@@ -322,7 +322,21 @@
       }
     });
   };
-  $('#fen').on('DOMSubtreeModified', sendFen);
+
+  // Register a MutationObserver to look at fen changes
+  const fenElement = document.getElementById('fen');
+  if (fenElement) {
+    const observer = new MutationObserver((mutationsList) => {
+      // Send the new fen to the backend
+      sendFen();
+    });
+    // Observe the fen textbox
+    observer.observe(fenElement, {
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
+  }
 
   // Update the graph and kibitzers every second
   setInterval(() => {


### PR DESCRIPTION
Replacing a deprecated event with a much more broadly supported API.
Solves https://github.com/GediminasMasaitis/CcrlExtensions/issues/14
Solves https://github.com/GediminasMasaitis/CcrlExtensions/issues/15