### PR TITLE
🐛 Show again kibitzer name in chart legend

### DIFF
--- a/src/front/ccrlExtensions.js
+++ b/src/front/ccrlExtensions.js
@@ -367,10 +367,10 @@
           $(`#kibitzer${kibitzerNum}-nodes`).text(formatCompactNumber(info.nodes));
           $(`#kibitzer${kibitzerNum}-nps`).text(formatCompactNumber(info.nps));
 
-          // Update kibitzer scores for the chart (positions 2 and 3 in the scores array)
+          // Update kibitzer scores and labels for the chart (positions 2 and 3 in the scores array)
           const datasetIndex = 2 + index;
           scores[datasetIndex][plyStr] = { x: plyStr, y: parseScore(info.score).value, tooltip: parseScore(info.score).tooltip };
-
+          chart.data.datasets[datasetIndex].label = info.name;
 
           let multipvHtml = "";
           if (info.multipv) {


### PR DESCRIPTION
We removed this part in https://github.com/GediminasMasaitis/CcrlExtensions/pull/11/files, I believe that accidentally (@TheRealGioviok could you double check?).

Closes #17.

After the fix:

![image](https://github.com/user-attachments/assets/9b3c330b-67a2-4e3e-a8bd-1d4c6b32f9a9)
